### PR TITLE
Add KDoc to all public API elements

### DIFF
--- a/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/LocalSWRCacheOwner.kt
+++ b/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/LocalSWRCacheOwner.kt
@@ -7,10 +7,26 @@ import androidx.compose.runtime.compositionLocalOf
 import com.kazakago.swr.store.cache.SWRCacheOwner
 import com.kazakago.swr.store.cache.defaultSWRCacheOwner
 
+/**
+ * CompositionLocal that provides the current [SWRCacheOwner].
+ *
+ * Defaults to [defaultSWRCacheOwner]. Override with the [SWRCacheOwner] composable to isolate
+ * the SWR cache namespace (e.g. per user session or feature scope).
+ */
 public val LocalSWRCacheOwner: ProvidableCompositionLocal<SWRCacheOwner> = compositionLocalOf {
     defaultSWRCacheOwner
 }
 
+/**
+ * Overrides the [SWRCacheOwner] for all SWR composables within [content].
+ *
+ * Use this to isolate the cache namespace, for example when switching user accounts
+ * or scoping data to a particular feature.
+ *
+ * @param cacheOwner The [SWRCacheOwner] to use within [content].
+ * @param content The composable subtree that uses this cache owner.
+ * @see LocalSWRCacheOwner
+ */
 @Composable
 public fun SWRCacheOwner(
     cacheOwner: SWRCacheOwner,

--- a/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/LocalSWRConfig.kt
+++ b/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/LocalSWRConfig.kt
@@ -7,10 +7,26 @@ import androidx.compose.runtime.compositionLocalOf
 import com.kazakago.swr.runtime.SWRConfig
 import com.kazakago.swr.runtime.defaultSWRConfig
 
+/**
+ * CompositionLocal that provides the current [SWRConfig].
+ *
+ * Defaults to [defaultSWRConfig]. Override with the [SWRConfig] composable to apply
+ * scoped configuration to a subtree of composables.
+ */
 public val LocalSWRConfig: ProvidableCompositionLocal<SWRConfig<Any, Any>> = compositionLocalOf {
     defaultSWRConfig
 }
 
+/**
+ * Applies scoped SWR configuration to all SWR composables within [content].
+ *
+ * Configuration values are merged with the current [LocalSWRConfig], so only the properties
+ * explicitly set in [config] are overridden. Equivalent to React SWR's `<SWRConfig>` provider.
+ *
+ * @param config Lambda to configure options on the current [SWRConfig].
+ * @param content The composable subtree that inherits this configuration.
+ * @see LocalSWRConfig
+ */
 @Composable
 public fun SWRConfig(
     config: SWRConfig<Any, Any>.() -> Unit,

--- a/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWR.kt
+++ b/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWR.kt
@@ -18,6 +18,19 @@ import com.kazakago.swr.store.persister.Persister
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.map
 
+/**
+ * Fetches and auto-revalidates data for [key], returning the result as Compose state.
+ *
+ * Equivalent to React SWR's `useSWR`. Revalidates on mount, when the app regains focus,
+ * when the network reconnects, and at the configured [refreshInterval][SWRConfig.refreshInterval].
+ *
+ * @param key The cache key. Pass `null` to suspend fetching until a non-null key is provided.
+ * @param fetcher Suspending function that fetches data for [key].
+ * @param persister Optional persistence layer for cross-session caching.
+ * @param scope CoroutineScope for revalidation jobs. Defaults to the current composition scope.
+ * @param config Additional configuration options, merged with [LocalSWRConfig].
+ * @return The current [SWRState] as Compose state.
+ */
 @Composable
 public fun <KEY : Any, DATA> rememberSWR(
     key: KEY?,

--- a/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWRImmutable.kt
+++ b/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWRImmutable.kt
@@ -16,6 +16,19 @@ import com.kazakago.swr.store.persister.Persister
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.map
 
+/**
+ * Fetches data for [key] once and never revalidates automatically.
+ *
+ * Equivalent to React SWR's `useSWRImmutable`. Use this for static or rarely changing data.
+ * [SWRState.mutate] can still be called to trigger a manual refresh.
+ *
+ * @param key The cache key. Pass `null` to suspend fetching until a non-null key is provided.
+ * @param fetcher Suspending function that fetches data for [key].
+ * @param persister Optional persistence layer for cross-session caching.
+ * @param scope CoroutineScope for the initial fetch. Defaults to the current composition scope.
+ * @param config Additional configuration options, merged with [LocalSWRConfig].
+ * @return The current [SWRState] as Compose state.
+ */
 @Composable
 public fun <KEY : Any, DATA> rememberSWRImmutable(
     key: KEY?,

--- a/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWRInfinite.kt
+++ b/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWRInfinite.kt
@@ -17,6 +17,21 @@ import com.kazakago.swr.store.persister.Persister
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.map
 
+/**
+ * Fetches paginated data, returning the result as Compose state.
+ *
+ * Equivalent to React SWR's `useSWRInfinite`. Load more pages by incrementing
+ * [SWRInfiniteState.size] via [SWRInfiniteState.setSize].
+ *
+ * @param getKey Returns the cache key for a page given its index and the previous page's data.
+ *               Return `null` to stop loading further pages.
+ * @param fetcher Suspending function that fetches data for a single page key.
+ * @param persister Optional persistence layer for cross-session caching.
+ * @param scope CoroutineScope for revalidation jobs. Defaults to the current composition scope.
+ * @param config Additional configuration options (e.g. [SWRConfig.initialSize], [SWRConfig.parallel]),
+ *               merged with [LocalSWRConfig].
+ * @return The current [SWRInfiniteState] as Compose state.
+ */
 @Composable
 public fun <KEY : Any, DATA> rememberSWRInfinite(
     getKey: (pageIndex: Int, previousPageData: DATA?) -> KEY?,

--- a/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWRMutation.kt
+++ b/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWRMutation.kt
@@ -8,6 +8,18 @@ import com.kazakago.swr.runtime.SWRMutation
 import com.kazakago.swr.runtime.SWRMutationConfig
 import com.kazakago.swr.store.persister.Persister
 
+/**
+ * Returns a [SWRMutationState] for manually triggering data mutation.
+ *
+ * Equivalent to React SWR's `useSWRMutation`. Unlike [rememberSWR], no fetch is triggered
+ * automatically; call [SWRMutationState.trigger] to initiate the mutation.
+ *
+ * @param key The cache key targeted by this mutation. Pass `null` to disable mutation.
+ * @param fetcher Suspending function that performs the mutation given a key and an argument.
+ * @param persister Optional persistence layer for cross-session caching.
+ * @param config Mutation-specific configuration options.
+ * @return [SWRMutationState] exposing [trigger][SWRMutationState.trigger], mutation state, and [reset][SWRMutationState.reset].
+ */
 @Composable
 public fun <KEY : Any, DATA, ARG> rememberSWRMutation(
     key: KEY?,

--- a/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWRPreload.kt
+++ b/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWRPreload.kt
@@ -8,6 +8,20 @@ import com.kazakago.swr.runtime.SWRPreload
 import com.kazakago.swr.store.persister.Persister
 import kotlinx.coroutines.CoroutineScope
 
+/**
+ * Returns a [SWRPreload] that prefetches data for [key] on demand.
+ *
+ * Equivalent to React SWR's `preload`. The returned instance is a suspending operator
+ * function that, when invoked, fetches data and stores it in the cache without binding
+ * to the composable's lifecycle.
+ *
+ * @param key The cache key. Pass `null` to disable prefetching.
+ * @param fetcher Suspending function that fetches data for [key].
+ * @param persister Optional persistence layer for cross-session caching.
+ * @param scope CoroutineScope for the prefetch job. Defaults to the current composition scope.
+ * @param config Additional configuration options, merged with [LocalSWRConfig].
+ * @return A [SWRPreload] instance that can be invoked to trigger the prefetch.
+ */
 @Composable
 public fun <KEY : Any, DATA> rememberSWRPreload(
     key: KEY?,

--- a/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWRSubscription.kt
+++ b/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/RememberSWRSubscription.kt
@@ -12,6 +12,22 @@ import com.kazakago.swr.store.persister.Persister
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Subscribes to a real-time data source and returns the latest value as Compose state.
+ *
+ * Equivalent to React SWR's `useSWRSubscription`. The [subscribe] lambda returns a [Flow]
+ * whose emissions are written to the SWR cache and reflected in [SWRSubscriptionState.data].
+ *
+ * The subscription is cancelled only when [key] changes, not when the composable leaves
+ * composition. To keep the subscription alive across screen transitions, pass an external
+ * [scope] such as `viewModelScope`.
+ *
+ * @param key The cache key. Pass `null` to skip subscribing.
+ * @param scope CoroutineScope for collecting the subscription flow. Defaults to the current composition scope.
+ * @param persister Optional persistence layer for cross-session caching.
+ * @param subscribe Suspending function that returns a [Flow] of data for [key].
+ * @return The current [SWRSubscriptionState] as Compose state.
+ */
 @Composable
 public fun <KEY : Any, DATA> rememberSWRSubscription(
     key: KEY?,

--- a/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/SWRMutationState.kt
+++ b/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/SWRMutationState.kt
@@ -3,11 +3,25 @@ package com.kazakago.swr.compose
 import androidx.compose.runtime.Immutable
 import com.kazakago.swr.runtime.SWRTrigger
 
+/**
+ * Compose state returned by [rememberSWRMutation].
+ *
+ * Equivalent to the return value of React SWR's `useSWRMutation`.
+ */
 @Immutable
 public data class SWRMutationState<KEY : Any, DATA, ARG>(
+    /** Call this to trigger the mutation. */
     val trigger: SWRTrigger<KEY, DATA, ARG>,
+
+    /** `true` while a mutation is in progress. */
     val isMutating: Boolean,
+
+    /** The data returned by the last successful mutation, or `null` if none has occurred. */
     val data: DATA?,
+
+    /** The error thrown by the last failed mutation, or `null` if none has occurred. */
     val error: Throwable?,
+
+    /** Resets [data], [error], and [isMutating] to their initial values. */
     val reset: () -> Unit,
 )

--- a/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/SWRSubscriptionState.kt
+++ b/swr-compose/src/commonMain/kotlin/com/kazakago/swr/compose/SWRSubscriptionState.kt
@@ -2,8 +2,16 @@ package com.kazakago.swr.compose
 
 import androidx.compose.runtime.Immutable
 
+/**
+ * Compose state returned by [rememberSWRSubscription].
+ *
+ * Equivalent to the return value of React SWR's `useSWRSubscription`.
+ */
 @Immutable
 public data class SWRSubscriptionState<DATA>(
+    /** The most recently emitted value from the subscription, or `null` if none has arrived yet. */
     val data: DATA?,
+
+    /** The error thrown by the subscription, or `null` if no error has occurred. */
     val error: Throwable?,
 )

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/DedupingIntervalException.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/DedupingIntervalException.kt
@@ -1,3 +1,7 @@
 package com.kazakago.swr.runtime
 
+/**
+ * Thrown internally when a revalidation is skipped because an identical request was made
+ * within the [dedupingInterval][SWRConfig.dedupingInterval].
+ */
 public class DedupingIntervalException : RuntimeException()

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/PausedException.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/PausedException.kt
@@ -1,3 +1,6 @@
 package com.kazakago.swr.runtime
 
+/**
+ * Thrown internally when a revalidation is skipped because [SWRConfig.isPaused] returned `true`.
+ */
 public class PausedException : RuntimeException()

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRConfig.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRConfig.kt
@@ -3,34 +3,104 @@ package com.kazakago.swr.runtime
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+/** The process-wide default [SWRConfig] used when no custom configuration is provided. */
 public val defaultSWRConfig: SWRConfig<Any, Any> = SWRConfig()
 
+/**
+ * Configuration options that control SWR data-fetching behavior.
+ *
+ * These options mirror [React SWR's options](https://swr.vercel.app/docs/api#options).
+ * Apply globally via [LocalSWRConfig][com.kazakago.swr.compose.LocalSWRConfig],
+ * or per-hook via the trailing `config` lambda.
+ *
+ * Options prefixed with `initial` / `revalidateAll` / `revalidateFirstPage` / `persistSize` / `parallel`
+ * apply only to [SWRInfinite] / [rememberSWRInfinite][com.kazakago.swr.compose.rememberSWRInfinite].
+ */
 public class SWRConfig<KEY : Any, DATA>(
+    /** Revalidate data even when cached (stale) data already exists. Default: `true`. */
     public var revalidateIfStale: Boolean = true,
+
+    /**
+     * Revalidate when the composable mounts.
+     * `null` inherits the value of [revalidateIfStale]. Default: `null`.
+     */
     public var revalidateOnMount: Boolean? = null,
+
+    /** Revalidate when the app regains focus. Default: `true`. */
     public var revalidateOnFocus: Boolean = true,
+
+    /** Revalidate when the network reconnects. Default: `true`. */
     public var revalidateOnReconnect: Boolean = true,
+
+    /** Polling interval. Set to `Duration.ZERO` to disable polling. Default: `0.seconds`. */
     public var refreshInterval: Duration = 0.seconds,
+
+    /** Continue polling even when the app is in the background. Default: `false`. */
     public var refreshWhenHidden: Boolean = false,
+
+    /** Continue polling even when the device is offline. Default: `false`. */
     public var refreshWhenOffline: Boolean = false,
+
+    /** Automatically retry when a fetch fails. Default: `true`. */
     public var shouldRetryOnError: Boolean = true,
+
+    /** Deduplicate requests with the same key within this interval. Default: `2.seconds`. */
     public var dedupingInterval: Duration = 2.seconds,
+
+    /** Throttle focus-triggered revalidations within this interval. Default: `5.seconds`. */
     public var focusThrottleInterval: Duration = 5.seconds,
+
+    /** Duration after which [onLoadingSlow] is called if the fetch has not completed. Default: `3.seconds`. */
     public var loadingTimeout: Duration = 3.seconds,
+
+    /** Base interval for the exponential backoff retry strategy. Default: `5.seconds`. */
     public var errorRetryInterval: Duration = 5.seconds,
+
+    /** Maximum number of retry attempts. `null` means unlimited. Default: `null`. */
     public var errorRetryCount: Int? = null,
+
+    /** Data to return before any fetch completes, as a placeholder. Default: `null`. */
     public var fallbackData: DATA? = null,
+
+    /** Called when a fetch takes longer than [loadingTimeout] to complete. */
     public var onLoadingSlow: ((key: KEY, config: SWRConfig<KEY, DATA>) -> Unit)? = null,
+
+    /** Called after data is successfully fetched. */
     public var onSuccess: ((data: DATA, key: KEY, config: SWRConfig<KEY, DATA>) -> Unit)? = null,
+
+    /** Called when a fetch fails. */
     public var onError: ((error: Throwable, key: KEY, config: SWRConfig<KEY, DATA>) -> Unit)? = null,
+
+    /**
+     * Custom error retry handler.
+     * Defaults to [OnErrorRetryDefault], which implements exponential backoff.
+     */
     public var onErrorRetry: suspend (error: Throwable, key: KEY, config: SWRConfig<KEY, DATA>, revalidate: suspend (option: SWRValidateOptions) -> Unit, options: SWRValidateOptions) -> Unit = OnErrorRetryDefault,
 
+    // SWRInfinite-specific options
+
+    /** Initial number of pages to load. Default: `1`. */
     public var initialSize: Int = 1,
+
+    /** Revalidate all pages on focus or reconnect. Default: `false`. */
     public var revalidateAll: Boolean = false,
+
+    /** Revalidate only the first page on focus or reconnect. Default: `true`. */
     public var revalidateFirstPage: Boolean = true,
+
+    /** Preserve the current page count when the key changes. Default: `false`. */
     public var persistSize: Boolean = false,
+
+    /** Retain the previous data while new data for a changed key is loading. Default: `false`. */
     public var keepPreviousData: Boolean = false,
+
+    /** Fetch all pages in parallel instead of sequentially. Default: `false`. */
     public var parallel: Boolean = false,
+
+    /**
+     * Suspend all revalidations while this lambda returns `true`.
+     * Throws [PausedException] internally when paused. Default: `null` (never paused).
+     */
     public var isPaused: (() -> Boolean)? = null,
 ) {
     @Suppress("UNCHECKED_CAST")

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRImmutable.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRImmutable.kt
@@ -14,6 +14,21 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+/**
+ * Like [SWR], but disables all automatic revalidation after the initial fetch.
+ *
+ * Equivalent to React SWR's `useSWRImmutable`. Suitable for data that does not change,
+ * such as static configuration or user constants.
+ * Used internally by [rememberSWRImmutable][com.kazakago.swr.compose.rememberSWRImmutable].
+ *
+ * @param key The cache key. Pass `null` to suspend fetching.
+ * @param fetcher Suspending function that fetches data for [key].
+ * @param lifecycleOwner Lifecycle used to scope the initial fetch.
+ * @param scope CoroutineScope for the fetch job.
+ * @param persister Optional persistence layer for cross-session caching.
+ * @param cacheOwner Cache namespace. Defaults to [defaultSWRCacheOwner].
+ * @param config Additional configuration options, merged with [defaultConfig].
+ */
 public class SWRImmutable<KEY : Any, DATA>(
     key: KEY?,
     fetcher: suspend (key: KEY) -> DATA,
@@ -42,8 +57,10 @@ public class SWRImmutable<KEY : Any, DATA>(
         null
     }
 
+    /** Flow of the current cache state for this key. */
     public val stateFlow: StateFlow<SWRStoreState<DATA>> = swrInternal?.stateFlow ?: MutableStateFlow(SWRStoreState.initialize())
 
+    /** Handle for programmatically mutating the cache entry for this key. */
     public val mutate: SWRMutate<DATA> = if (swrInternal != null) {
         SWRMutate(
             get = swrInternal.store::get,

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRInfiniteMutate.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRInfiniteMutate.kt
@@ -4,6 +4,13 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
+/**
+ * Handle for programmatically mutating the SWR Infinite cache across all loaded pages.
+ *
+ * Obtained from [SWRInfiniteState.mutate][com.kazakago.swr.compose.SWRInfiniteState.mutate]
+ * or [SWRInfinite.mutate].
+ * Equivalent to the bound `mutate` function returned by React SWR's `useSWRInfinite`.
+ */
 public data class SWRInfiniteMutate<DATA>(
     private val getSize: suspend () -> Int,
     private val get: suspend (pageIndex: Int) -> Result<DATA?>,
@@ -11,6 +18,14 @@ public data class SWRInfiniteMutate<DATA>(
     private val update: suspend (pageIndex: Int, newData: DATA?) -> Unit,
 ) {
 
+    /**
+     * Mutates the cached data for all currently loaded pages.
+     *
+     * @param data Optional suspending function that returns the new list of page data.
+     *             If `null`, only a revalidation of all pages is triggered.
+     * @param config Mutation options such as optimistic updates, rollback on error, etc.
+     * @return The result of the mutation, wrapping the new page list or `null` if [data] was `null`.
+     */
     public suspend operator fun invoke(
         data: (suspend () -> List<DATA>)? = null,
         config: SWRMutateConfig<List<DATA>>.() -> Unit = {},

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRMutate.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRMutate.kt
@@ -2,12 +2,26 @@ package com.kazakago.swr.runtime
 
 import com.kazakago.swr.store.GettingFrom
 
+/**
+ * Handle for programmatically mutating the SWR cache for a single key.
+ *
+ * Obtained from [SWRState.mutate][com.kazakago.swr.compose.SWRState.mutate] or [SWR.mutate].
+ * Equivalent to the bound `mutate` function returned by React SWR's `useSWR`.
+ */
 public data class SWRMutate<DATA>(
     private val get: suspend (from: GettingFrom) -> Result<DATA>,
     private val validate: suspend () -> Result<DATA>,
     private val update: suspend (newData: DATA?, keepState: Boolean) -> Unit,
 ) {
 
+    /**
+     * Mutates the cached data.
+     *
+     * @param data Optional suspending function that produces the new data.
+     *             If `null`, only a revalidation is triggered without updating the cache value.
+     * @param config Mutation options such as optimistic updates, rollback on error, etc.
+     * @return The result of the mutation, wrapping the new data or `null` if [data] was `null`.
+     */
     public suspend operator fun invoke(
         data: (suspend () -> DATA)? = null,
         config: SWRMutateConfig<DATA>.() -> Unit = {},

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRMutateConfig.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRMutateConfig.kt
@@ -1,8 +1,20 @@
 package com.kazakago.swr.runtime
 
+/**
+ * Configuration for a single [SWRMutate] call.
+ *
+ * Equivalent to React SWR's `MutatorOptions`.
+ */
 public data class SWRMutateConfig<DATA>(
+    /** Optimistic data to display immediately while the mutation is in progress. */
     var optimisticData: DATA? = null,
+
+    /** If `true`, revalidate from the remote source after the mutation completes. Default: `true`. */
     var revalidate: Boolean = true,
+
+    /** If `true`, update the cache with the value returned by the mutation. Default: `true`. */
     var populateCache: Boolean = true,
+
+    /** If `true`, revert to the previous cached data when the mutation fails. Default: `true`. */
     var rollbackOnError: Boolean = true,
 )

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRMutationConfig.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRMutationConfig.kt
@@ -1,10 +1,26 @@
 package com.kazakago.swr.runtime
 
+/**
+ * Configuration for a single [SWRTrigger] call.
+ *
+ * Equivalent to React SWR's `SWRMutationConfiguration`.
+ */
 public class SWRMutationConfig<KEY : Any, DATA> {
+    /** Optimistic data to display immediately while the mutation is in progress. */
     public var optimisticData: DATA? = null
+
+    /** If `true`, revalidate from the remote source after the mutation completes. Default: `true`. */
     public var revalidate: Boolean = true
+
+    /** If `true`, update the SWR cache with the value returned by the mutation. Default: `false`. */
     public var populateCache: Boolean = false
+
+    /** If `true`, revert to the previous cached data when the mutation fails. Default: `true`. */
     public var rollbackOnError: Boolean = true
+
+    /** Called when the mutation succeeds. */
     public var onSuccess: ((data: DATA, key: KEY, config: SWRMutationConfig<KEY, DATA>) -> Unit)? = null
+
+    /** Called when the mutation fails. */
     public var onError: ((error: Throwable, key: KEY, config: SWRMutationConfig<KEY, DATA>) -> Unit)? = null
 }

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRPreload.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRPreload.kt
@@ -7,6 +7,20 @@ import com.kazakago.swr.store.cache.defaultSWRCacheOwner
 import com.kazakago.swr.store.persister.Persister
 import kotlinx.coroutines.CoroutineScope
 
+/**
+ * Prefetches data for [key] and stores the result in the SWR cache.
+ *
+ * Unlike [SWR], this is not bound to a lifecycle; the fetch is triggered on demand by invoking
+ * the returned instance. Equivalent to React SWR's `preload`.
+ * Used internally by [rememberSWRPreload][com.kazakago.swr.compose.rememberSWRPreload].
+ *
+ * @param key The cache key. Pass `null` to disable prefetching.
+ * @param fetcher Suspending function that fetches data for [key].
+ * @param scope CoroutineScope for the prefetch job.
+ * @param persister Optional persistence layer for cross-session caching.
+ * @param cacheOwner Cache namespace. Defaults to [defaultSWRCacheOwner].
+ * @param config Additional configuration options, merged with [defaultConfig].
+ */
 public class SWRPreload<KEY : Any, DATA>(
     key: KEY?,
     fetcher: suspend (key: KEY) -> DATA,
@@ -26,6 +40,12 @@ public class SWRPreload<KEY : Any, DATA>(
         null
     }
 
+    /**
+     * Triggers the prefetch and returns the result.
+     *
+     * Within the [dedupingInterval][SWRConfig.dedupingInterval], subsequent calls return
+     * the cached result immediately without issuing a new network request.
+     */
     public suspend operator fun invoke(): Result<DATA> {
         return validate?.invoke() ?: Result.failure(IllegalStateException("key is null"))
     }

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRTrigger.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRTrigger.kt
@@ -1,8 +1,20 @@
 package com.kazakago.swr.runtime
 
+/**
+ * Handle for triggering a [SWRMutation].
+ *
+ * Obtained from [SWRMutationState.trigger][com.kazakago.swr.compose.SWRMutationState.trigger].
+ */
 public data class SWRTrigger<KEY : Any, DATA, ARG>(
     private val trigger: suspend (arg: ARG, config: SWRMutationConfig<KEY, DATA>.() -> Unit) -> Result<DATA>,
 ) {
+    /**
+     * Triggers the mutation.
+     *
+     * @param arg The argument passed to the mutation fetcher.
+     * @param config Per-call configuration overrides applied on top of the default [SWRMutationConfig].
+     * @return The result of the mutation.
+     */
     public suspend operator fun invoke(
         arg: ARG,
         config: SWRMutationConfig<KEY, DATA>.() -> Unit = {},

--- a/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRValidateOptions.kt
+++ b/swr-runtime/src/commonMain/kotlin/com/kazakago/swr/runtime/SWRValidateOptions.kt
@@ -1,6 +1,12 @@
 package com.kazakago.swr.runtime
 
+/**
+ * Options passed to [SWRConfig.onErrorRetry] to control retry behavior.
+ */
 public data class SWRValidateOptions(
+    /** The current retry attempt count (0-based). */
     public val retryCount: Int,
+
+    /** Whether this revalidation is within the [dedupingInterval][SWRConfig.dedupingInterval] window. */
     public val dedupe: Boolean,
 )

--- a/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/GettingFrom.kt
+++ b/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/GettingFrom.kt
@@ -1,7 +1,15 @@
 package com.kazakago.swr.store
 
+/**
+ * Specifies the source to read data from when calling [SWRStore.get].
+ */
 public enum class GettingFrom {
+    /** Read from the in-memory cache first; fall back to a remote fetch if no data is cached. */
     Both,
+
+    /** Always fetch from the remote source, bypassing the in-memory cache. */
     RemoteOnly,
+
+    /** Read only from the in-memory cache; never trigger a remote fetch. */
     LocalOnly,
 }

--- a/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/SWRAlreadyLoadingException.kt
+++ b/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/SWRAlreadyLoadingException.kt
@@ -1,3 +1,6 @@
 package com.kazakago.swr.store
 
+/**
+ * Thrown when a fetch is triggered while another fetch for the same key is already in progress.
+ */
 public class SWRAlreadyLoadingException : RuntimeException()

--- a/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/SWRStore.kt
+++ b/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/SWRStore.kt
@@ -7,6 +7,18 @@ import com.kazakago.swr.store.persister.Persister
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 
+/**
+ * Low-level cache store that coordinates data fetching and caching for a single key.
+ *
+ * Manages the full lifecycle of a cache entry: initial load, background revalidation,
+ * optimistic updates, and optional persistence. Higher-level classes such as [SWR][com.kazakago.swr.runtime.SWR]
+ * and [SWRInfinite][com.kazakago.swr.runtime.SWRInfinite] compose [SWRStore] internally.
+ *
+ * @param key The cache key identifying this store's entry.
+ * @param fetcher Suspending function that retrieves data from a remote source.
+ * @param persister Optional persistence layer for cross-session caching.
+ * @param cacheOwner Cache namespace. Defaults to the global [defaultSWRCacheOwner].
+ */
 public class SWRStore<KEY : Any, DATA>(
     public val key: KEY,
     private val fetcher: suspend (key: KEY) -> DATA,
@@ -37,28 +49,50 @@ public class SWRStore<KEY : Any, DATA>(
         },
     )
 
+    /** Emits a signal whenever a revalidation has been externally requested via [requestRevalidation]. */
     public val revalidationSignal: SharedFlow<Unit> = cacheOwner.getOrPut(key).revalidationSignal
 
+    /** Emits a revalidation signal to all observers of [revalidationSignal]. */
     public suspend fun requestRevalidation() {
         cacheOwner.getOrPut(key).requestRevalidation()
     }
 
+    /** A flow that emits the current [SWRStoreState] whenever the cache state changes. */
     public val flow: Flow<SWRStoreState<DATA>> = dataSelector.flow
 
+    /**
+     * Retrieves the current data.
+     *
+     * @param from Specifies the source to read from. Defaults to [GettingFrom.Both].
+     */
     public suspend fun get(from: GettingFrom = GettingFrom.Both): Result<DATA> = dataSelector.get(from)
 
+    /**
+     * Triggers a revalidation (re-fetch) of the data.
+     * Skipped if a fetch is already in progress for this key.
+     */
     public suspend fun validate(): Result<DATA> {
         return dataSelector.validate()
     }
 
+    /**
+     * Forces a fresh fetch from the remote source, bypassing the deduplication interval.
+     */
     public suspend fun refresh(): Result<DATA> {
         return dataSelector.refresh()
     }
 
+    /**
+     * Updates the cached data directly without triggering a remote fetch.
+     *
+     * @param data The new data to store, or `null` to clear the cached value.
+     * @param keepState If `true`, the current loading/error state is preserved after the update.
+     */
     public suspend fun update(data: DATA?, keepState: Boolean = false) {
         dataSelector.update(data, keepState)
     }
 
+    /** Clears the cached data and resets the store to the initial loading state. */
     public suspend fun clear() {
         dataSelector.clear()
     }

--- a/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/SWRStoreState.kt
+++ b/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/SWRStoreState.kt
@@ -1,19 +1,35 @@
 package com.kazakago.swr.store
 
+/**
+ * Represents the state of a single SWR cache entry.
+ *
+ * This is the core state type propagated through all SWR layers.
+ * Use [isValidating], [data], and [error] for exhaustive state handling.
+ */
 public sealed interface SWRStoreState<out T> {
 
     public companion object {
+        /** Returns the initial state used before any fetch has been started. */
         public fun <T> initialize(): SWRStoreState<T> = Loading(null)
     }
 
+    /** The currently cached data, or `null` if not yet available. */
     public val data: T?
+
+    /** The error from the last failed fetch, or `null` if no error occurred. */
     public val error: Throwable?
+
+    /** `true` while a fetch or revalidation is in progress. */
     public val isValidating: Boolean
 
     public operator fun component1(): T? = data
     public operator fun component2(): Throwable? = error
     public operator fun component3(): Boolean = isValidating
 
+    /**
+     * A fetch or revalidation is in progress.
+     * [data] may be non-null when this represents a background refresh of stale data.
+     */
     public data class Loading<out T>(
         override val data: T?,
     ) : SWRStoreState<T> {
@@ -21,6 +37,9 @@ public sealed interface SWRStoreState<out T> {
         override val isValidating: Boolean = true
     }
 
+    /**
+     * Data was fetched successfully and no revalidation is currently in progress.
+     */
     public data class Completed<out T>(
         override val data: T,
     ) : SWRStoreState<T> {
@@ -28,6 +47,10 @@ public sealed interface SWRStoreState<out T> {
         override val isValidating: Boolean = false
     }
 
+    /**
+     * The last fetch attempt failed.
+     * [data] may retain a previously cached value if available.
+     */
     public data class Error<out T>(
         override val data: T?,
         override val error: Throwable,

--- a/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/cache/SWRCache.kt
+++ b/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/cache/SWRCache.kt
@@ -6,30 +6,48 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
+/** The process-wide default [SWRCacheOwner] shared across all SWR instances. */
 public val defaultSWRCacheOwner: SWRCacheOwner = SWRCacheOwner()
 
+/**
+ * Manages all cache entries within a given scope.
+ *
+ * Use [LocalSWRCacheOwner][com.kazakago.swr.compose.LocalSWRCacheOwner] in Compose, or provide
+ * a custom instance to isolate cache namespaces (e.g. per user session).
+ */
 public class SWRCacheOwner {
+    /** The backing map of cache entries, keyed by SWR key. */
     public val cacheMap: MutableMap<Any, SWRCache> = mutableMapOf()
 
+    /** Returns the [SWRCache] for [key], creating a new entry if one does not exist. */
     public fun <KEY : Any> getOrPut(key: KEY): SWRCache {
         return cacheMap.getOrPut(key) { SWRCache() }
     }
 
+    /** Clears all cached data across every entry in this owner. */
     public fun clearAll() {
         cacheMap.forEach { it.value.clear() }
     }
 }
 
+/**
+ * Holds the cached state for a single SWR key.
+ */
 public class SWRCache {
+    /** The currently cached data value. Type-erased at this layer. */
     public var data: Any? = null
     internal val stateMapFlow: MutableStateFlow<DataState> = MutableStateFlow(DataState.initialize())
     private val _revalidationSignal: MutableSharedFlow<Unit> = MutableSharedFlow()
+
+    /** A shared flow that emits whenever a revalidation is requested for this cache entry. */
     public val revalidationSignal: SharedFlow<Unit> = _revalidationSignal.asSharedFlow()
 
+    /** Emits a revalidation signal to all current subscribers. */
     public suspend fun requestRevalidation() {
         _revalidationSignal.emit(Unit)
     }
 
+    /** Clears the cached data and resets state to the initial loading state. */
     public fun clear() {
         data = null
         stateMapFlow.value = DataState.initialize()

--- a/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/persister/Persister.kt
+++ b/swr-store/src/commonMain/kotlin/com/kazakago/swr/store/persister/Persister.kt
@@ -1,12 +1,29 @@
 package com.kazakago.swr.store.persister
 
+/**
+ * Defines a persistence layer for SWR cached data.
+ *
+ * Implement this interface to persist data across app restarts (e.g. using a local database or file).
+ * Pass an instance to `rememberSWR` or other SWR composables via the `persister` parameter.
+ */
 public interface Persister<KEY : Any, DATA> {
 
+    /** Loads persisted data for [key], or returns `null` if no data has been saved. */
     public suspend fun loadData(key: KEY): DATA?
 
+    /**
+     * Saves [data] for [key].
+     * Pass `null` to delete the persisted entry for [key].
+     */
     public suspend fun saveData(key: KEY, data: DATA?)
 }
 
+/**
+ * Creates a [Persister] from lambda functions.
+ *
+ * @param loadData Suspending function that loads data for a given key.
+ * @param saveData Suspending function that saves (or deletes when `null`) data for a given key.
+ */
 public fun <KEY : Any, DATA> Persister(
     loadData: suspend (key: KEY) -> DATA?,
     saveData: suspend (key: KEY, data: DATA?) -> Unit,


### PR DESCRIPTION
## Summary

- Add KDoc comments to all public classes, functions, and properties across the `swr-store`, `swr-runtime`, and `swr-compose` modules
- Documentation follows [React SWR's API reference](https://swr.vercel.app/docs/api) for behavioral descriptions, with Kotlin-specific adjustments where the interface differs
- All comments are written in English per the project's public-facing content rules

## Changes

- **swr-store**: `SWRStoreState`, `SWRStore`, `GettingFrom`, `SWRAlreadyLoadingException`, `SWRCacheOwner`, `SWRCache`, `Persister`
- **swr-runtime**: `SWRConfig` (all options), `SWR`, `SWRImmutable`, `SWRInfinite`, `SWRMutation`, `SWRSubscription`, `SWRPreload`, `SWRMutate`, `SWRInfiniteMutate`, `SWRTrigger`, `SWRMutateConfig`, `SWRMutationConfig`, `SWRValidateOptions`, `DedupingIntervalException`, `PausedException`
- **swr-compose**: `rememberSWR*` composables, `SWRState`, `SWRInfiniteState`, `SWRMutationState`, `SWRSubscriptionState`, `LocalSWRConfig`, `LocalSWRCacheOwner`

## Test plan

- [x] \`./gradlew swr-compose:jvmTest swr-runtime:jvmTest swr-store:jvmTest\` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)