### PR TITLE
Ignore .claude/worktrees directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ captures
 
 # Claude
 .claude/plans
+.claude/worktrees


### PR DESCRIPTION
## What

Add `.claude/worktrees` to `.gitignore` to prevent Claude Code worktree directories from being tracked in version control.

## Why

The `.claude/worktrees` directory is used by Claude Code for temporary worktree management and should not be committed to the repository, similar to how `.claude/plans` is already excluded.

## Changes

- Added `.claude/worktrees` to `.gitignore`

## Related

-

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)