### PR TITLE
chore(deps): ignore local plugin buildlogic.publish in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "ignoreDeps": ["buildlogic.publish"],
 }


### PR DESCRIPTION
This PR configures Renovate to ignore the local `buildlogic.publish` plugin to suppress lookup warnings, as it is a local plugin and cannot be resolved externally.