### PR TITLE
Migrate to explicit JVM target compiler options and restore Foojay resolver

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,11 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          distribution: temurin
-          java-version: 17
-
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - run: ./gradlew swr-store:jvmTest swr-runtime:jvmTest swr-compose:jvmTest
@@ -25,11 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          distribution: temurin
-          java-version: 17
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
@@ -40,11 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          distribution: temurin
-          java-version: 17
-
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - run: ./gradlew swr-store:iosSimulatorArm64Test swr-runtime:iosSimulatorArm64Test swr-compose:iosSimulatorArm64Test
@@ -53,11 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          distribution: temurin
-          java-version: 17
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
@@ -68,11 +48,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          distribution: temurin
-          java-version: 17
-
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - run: ./gradlew swr-store:jsBrowserTest swr-runtime:jsBrowserTest swr-compose:jsBrowserTest
@@ -81,11 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          distribution: temurin
-          java-version: 17
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -15,11 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          distribution: temurin
-          java-version: 17
-
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - run: ./gradlew webApp:wasmJsBrowserDistribution

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,6 @@ jobs:
         with:
           ref: ${{ needs.bump-version.outputs.version }}
 
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          distribution: temurin
-          java-version: 17
-
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - name: Publish to Maven Central

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -1,13 +1,10 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
-}
-
-kotlin {
-    jvmToolchain(libs.versions.jvm.get().toInt())
 }
 
 dependencies {

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -9,13 +10,16 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(libs.versions.jvm.get().toInt())
-
     android {
         namespace = "com.kazakago.swr.example"
         compileSdk = libs.versions.androidCompileSdk.get().toInt()
         minSdk = libs.versions.androidMinSdk.get().toInt()
-        androidResources.enable = true
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.get()))
+        }
+        androidResources{
+            enable = true
+        }
     }
 
     listOf(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,10 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 include(":example")
 include(":desktopApp")
 include(":androidApp")

--- a/swr-compose/build.gradle.kts
+++ b/swr-compose/build.gradle.kts
@@ -19,7 +19,9 @@ kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.get()))
         }
-        withHostTest {}
+        withHostTest {
+            isIncludeAndroidResources = true
+        }
     }
 
     iosArm64()

--- a/swr-compose/build.gradle.kts
+++ b/swr-compose/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -10,19 +11,26 @@ plugins {
 
 kotlin {
     explicitApi()
-    jvmToolchain(libs.versions.jvm.get().toInt())
 
     android {
         namespace = "com.kazakago.swr.compose"
         compileSdk = libs.versions.androidCompileSdk.get().toInt()
         minSdk = libs.versions.androidMinSdk.get().toInt()
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.get()))
+        }
         withHostTest {}
     }
 
     iosArm64()
     iosSimulatorArm64()
 
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.get()))
+            freeCompilerArgs.add("-Xjdk-release=${libs.versions.jvm.get()}")
+        }
+    }
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {

--- a/swr-runtime/build.gradle.kts
+++ b/swr-runtime/build.gradle.kts
@@ -17,7 +17,9 @@ kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.get()))
         }
-        withHostTest {}
+        withHostTest {
+            isIncludeAndroidResources = true
+        }
     }
 
     iosArm64()

--- a/swr-runtime/build.gradle.kts
+++ b/swr-runtime/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -8,19 +9,26 @@ plugins {
 
 kotlin {
     explicitApi()
-    jvmToolchain(libs.versions.jvm.get().toInt())
 
     android {
         namespace = "com.kazakago.swr.runtime"
         compileSdk = libs.versions.androidCompileSdk.get().toInt()
         minSdk = libs.versions.androidMinSdk.get().toInt()
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.get()))
+        }
         withHostTest {}
     }
 
     iosArm64()
     iosSimulatorArm64()
 
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.get()))
+            freeCompilerArgs.add("-Xjdk-release=${libs.versions.jvm.get()}")
+        }
+    }
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {

--- a/swr-store/build.gradle.kts
+++ b/swr-store/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -8,19 +9,26 @@ plugins {
 
 kotlin {
     explicitApi()
-    jvmToolchain(libs.versions.jvm.get().toInt())
 
     android {
         namespace = "com.kazakago.swr.store"
         compileSdk = libs.versions.androidCompileSdk.get().toInt()
         minSdk = libs.versions.androidMinSdk.get().toInt()
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.get()))
+        }
         withHostTest {}
     }
 
     iosArm64()
     iosSimulatorArm64()
 
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.get()))
+            freeCompilerArgs.add("-Xjdk-release=${libs.versions.jvm.get()}")
+        }
+    }
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {

--- a/swr-store/build.gradle.kts
+++ b/swr-store/build.gradle.kts
@@ -17,7 +17,9 @@ kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.get()))
         }
-        withHostTest {}
+        withHostTest {
+            isIncludeAndroidResources = true
+        }
     }
 
     iosArm64()


### PR DESCRIPTION
## What

Restore the Foojay resolver plugin for CI JDK provisioning and migrate all library/example modules from `jvmToolchain` to explicit `jvmTarget` compiler options.

## Why

`jvmToolchain` combined with explicit `setup-java` steps in CI was redundant and less flexible than letting the Foojay resolver plugin auto-provision the JDK, while explicit `compilerOptions.jvmTarget` gives finer-grained control per target (Android/JVM) than a single toolchain version. Enabling Android resources for host tests ensures resource-dependent tests run correctly on the JVM host test target.

## Changes

- Restore foojay resolver plugin and remove explicit JDK setup in CI
  - Remove `actions/setup-java` steps from `check.yml`, `demo.yml`, and `release.yml`
  - Re-enable the Foojay resolver plugin in `settings.gradle.kts`
- Replace `jvmToolchain` with explicit JVM target compiler options
  - Remove `kotlin { jvmToolchain(...) }` from `desktopApp`, `example`, `swr-compose`, `swr-runtime`, and `swr-store`
  - Set `compilerOptions.jvmTarget` explicitly for Android and JVM targets in each module
  - Add `-Xjdk-release` compiler arg for JVM targets in `swr-compose`, `swr-runtime`, and `swr-store`
- Enable Android resources for host tests in library modules
  - Set `isIncludeAndroidResources = true` in `withHostTest {}` for `swr-compose`, `swr-runtime`, and `swr-store`

## Related

-

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
